### PR TITLE
[FIX] adds logic for thread messages in developer-help handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Wallets Discord Bot
+
 A bot to take wallet related messages from Discord and move them a central slack channel for wallet devs
 
 ## Prerequisites
@@ -9,8 +10,9 @@ You will need
 - Yarn (>=v1.22.5): https://classic.yarnpkg.com/en/docs/install
 
 ## Development
+
 To start the server in development mode, run:
-`yarn i && yarn start`
+`yarn && yarn start`
 
 ## Production build
 


### PR DESCRIPTION
`message.channelId` is the thread ID if the message is inside a thread or in a post, in #developer-help this is most messages.