### PR TITLE
Fix Slack message URL formatting in developer-help cross-posting

### DIFF
--- a/src/service/discord-bot/developer-help.ts
+++ b/src/service/discord-bot/developer-help.ts
@@ -43,7 +43,7 @@ export const developerHelpWatchMessages = async (
 
     const res = await slackClient.chat.postMessage({
       channel: SLACK_POST_CHANNEL,
-      text: `channel: *${channelName}*, from *${message.author.username}*, [thread](${message.url}):
+      text: `channel: *${channelName}*, from *${message.author.username}*, <${message.url}|thread>:
 ${message.content}
       `,
     });


### PR DESCRIPTION
### What
  Change the formatting of Discord thread URLs in Slack messages from Markdown to Slack's custom link format.

  ### Why
  Markdown links were not rendering correctly in Slack messages, preventing users from clicking through to Discord threads.