### PR TITLE
Ignore replies in developerHelpWatchMessages

### DIFF
--- a/src/service/discord-bot/developer-help.ts
+++ b/src/service/discord-bot/developer-help.ts
@@ -1,10 +1,4 @@
-import {
-  ChannelType,
-  Client,
-  Message,
-  TextChannel,
-  ThreadChannel,
-} from "discord.js";
+import { ChannelType, Client, Message, TextChannel } from "discord.js";
 import { WebClient } from "@slack/web-api";
 import { Logger } from "pino";
 

--- a/src/service/discord-bot/developer-help.ts
+++ b/src/service/discord-bot/developer-help.ts
@@ -17,40 +17,26 @@ export const developerHelpWatchMessages = async (
   slackClient: WebClient,
   logger: Logger
 ) => {
-  // Ignore messages from bots
+  // Ignore messages from bots and replies
   if (message.author.bot) return;
+  if (message.reference) return;
 
-  if (
-    message.channelId == DISCORD_CHANNEL ||
-    (message.channel?.isThread() &&
-      message.channel.parentId === DISCORD_CHANNEL)
-  ) {
-    const channel = await discordClient.channels.fetch(message.channelId);
+  if (message.channelId !== DISCORD_CHANNEL) return;
 
-    let channelName: string;
-    if (channel?.type === ChannelType.GuildText) {
-      channelName = (channel as TextChannel).name;
-    } else if (channel?.isThread()) {
-      const thread = channel as ThreadChannel;
-      const parentName =
-        thread.parent?.type === ChannelType.GuildText
-          ? thread.parent.name
-          : "unknown";
-      channelName = `${parentName} > ${thread.name}`;
-    } else {
-      channelName = message.channelId;
-    }
+  const channel = await discordClient.channels.fetch(message.channelId);
+  const channelName =
+    channel?.type === ChannelType.GuildText
+      ? (channel as TextChannel).name
+      : message.channelId;
 
-    const res = await slackClient.chat.postMessage({
-      channel: SLACK_POST_CHANNEL,
-      text: `channel: *${channelName}*, from *${message.author.username}*, <${message.url}|thread>:
-${message.content}
-      `,
-    });
+  const res = await slackClient.chat.postMessage({
+    channel: SLACK_POST_CHANNEL,
+    text: `channel: *${channelName}*, from *${message.author.username}*, <${message.url}|post>:
+${message.content}`,
+  });
 
-    if (!res.ok) {
-      logger.error("Failed to post to slack");
-      logger.error(res.errors);
-    }
+  if (!res.ok) {
+    logger.error("Failed to post to slack");
+    logger.error(res.errors);
   }
 };


### PR DESCRIPTION

Changes to developerHelpWatchMessages:
Ignores replies in posts
Tweaks filter logic to only care about posts and not thread replies