### PR TITLE
Disable unfurls on developerhelp cross-posts

### DIFF
--- a/src/service/discord-bot/developer-help.ts
+++ b/src/service/discord-bot/developer-help.ts
@@ -41,8 +41,9 @@ export const developerHelpWatchMessages = async (
 
   const res = await slackClient.chat.postMessage({
     channel: SLACK_POST_CHANNEL,
-    text: `channel: *${channelName}*, from *${message.author.username}*, <${message.url}|post>:
+    text: `*${channelName}*, from *${message.author.username}*, <${message.url}|post>:
 ${message.content}`,
+    unfurl_links: false,
   });
 
   if (!res.ok) {


### PR DESCRIPTION
### What
  Disable unfurls on develope-help cross-posts

  ### Why
  Improved formatting enhances readability and disabling link unfurling prevents noise from automatic link expansions in Slack.